### PR TITLE
增加新的8M Flash分区表配置, 以在小容量设备上使用小聆小聆唤醒词

### DIFF
--- a/main/boards/atoms3-echo-base/README.md
+++ b/main/boards/atoms3-echo-base/README.md
@@ -32,8 +32,16 @@ Serial flasher config -> Flash size -> 8 MB
 
 **修改分区表：**
 
+使用ESP-SR提供的唤醒词
+
 ```
 Partition Table -> Custom partition CSV file -> partitions/v1/8m.csv
+```
+
+使用聆思AI提供的"小聆小聆"唤醒词
+
+```
+Partition Table -> Custom partition CSV file -> partitions/v1/8m_custom_wakeword.csv
 ```
 
 **关闭片外 PSRAM：**

--- a/main/boards/atoms3r-cam-m12-echo-base/README.md
+++ b/main/boards/atoms3r-cam-m12-echo-base/README.md
@@ -37,6 +37,10 @@ idf.py menuconfig
 
 按 `S` 保存，按 `Q` 退出。
 
+如果使用聆思AI提供的"小聆小聆"唤醒词, 请做如下修改:
+
+- `Partition Table` → `Custom partition CSV file` → 删除原有内容，输入 `partitions/v1/8m_custom_wakeword.csv`
+
 **编译**
 
 ```bash

--- a/main/boards/atoms3r-echo-base/README.md
+++ b/main/boards/atoms3r-echo-base/README.md
@@ -26,8 +26,16 @@ Serial flasher config -> Flash size -> 8 MB
 
 **修改分区表：**
 
+使用ESP-SR提供的唤醒词
+
 ```
 Partition Table -> Custom partition CSV file -> partitions/v1/8m.csv
+```
+
+使用聆思AI提供的"小聆小聆"唤醒词
+
+```
+Partition Table -> Custom partition CSV file -> partitions/v1/8m_custom_wakeword.csv
 ```
 
 **修改 psram 配置：**

--- a/partitions/v1/8m_custom_wakeword.csv
+++ b/partitions/v1/8m_custom_wakeword.csv
@@ -1,0 +1,7 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,    0x4000,
+otadata,  data, ota,     0xd000,    0x2000,
+phy_init, data, phy,     0xf000,    0x1000,
+model,    data, spiffs,  0x10000,   0x3F0000,
+ota_0,    app,  ota_0,   ,          0x380000,


### PR DESCRIPTION
增加新的8M Flash分区表配置, 以在小容量设备上使用小聆小聆唤醒词,
主要改动是删掉一个OTA分区, 扩大model分区的大小

```csv
# ESP-IDF Partition Table
# Name,   Type, SubType, Offset,  Size, Flags
nvs,      data, nvs,     0x9000,    0x4000,
otadata,  data, ota,     0xd000,    0x2000,
phy_init, data, phy,     0xf000,    0x1000,
model,    data, spiffs,  0x10000,   0x3F0000,
ota_0,    app,  ota_0,   ,          0x380000,
```